### PR TITLE
docs: fixed dev/hacking.rst: start-after pattern not found

### DIFF
--- a/docs/dev/hacking.rst
+++ b/docs/dev/hacking.rst
@@ -27,7 +27,7 @@ module, as instructed in the **[extension-crush.libcrush]** section of
 the `setup.cfg` file:
 
 .. literalinclude:: ../../setup.cfg
-   :start-after: [extension-crush.libcrush]
+   :start-after: [extension=crush.libcrush]
    :end-before: [build_ext]
    :language: ini
 
@@ -88,4 +88,3 @@ Debugging readthedocs
 - in https://readthedocs.org/projects/crush/builds/\*/ check all lines from the bottom
   some may contain error messages that are do not fail the build but do nothing useful
   either
-


### PR DESCRIPTION
Fixed docs build error:

```shell
[pbr] Generating ChangeLog
running build_sphinx
creating /home/k0ste/sandbox/GIT/python-crush/build
creating /home/k0ste/sandbox/GIT/python-crush/build/doctrees
creating /home/k0ste/sandbox/GIT/python-crush/build/html
[pbr] Writing ChangeLog
[pbr] Generating ChangeLog
[pbr] ChangeLog complete (0.0s)
[pbr] Generating AUTHORS
[pbr] AUTHORS complete (0.0s)
Running Sphinx v1.6.5
loading pickled environment... not yet created
loading intersphinx inventory from http://crush.readthedocs.org/en/latest/objects.inv...
intersphinx inventory has moved: http://crush.readthedocs.org/en/latest/objects.inv -> http://crush.readthedocs.io/en/latest/objects.inv
building [mo]: all of 0 po files
building [html]: all source files
updating environment: 5 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                                       

Warning, treated as error:
/home/k0ste/sandbox/GIT/python-crush/docs/dev/hacking.rst:29:start-after pattern not found: [extension-crush.libcrush]
```